### PR TITLE
Bow the clothesline and fix the print texture overlap

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -276,10 +276,14 @@ export default function App() {
       ctx.save();
       ctx.globalAlpha = 0.54;
       ctx.font = '400 17px "IBM Plex Mono", monospace';
+      // step from the measured string, not a magic number: at 17px the run is
+      // ~337px wide, so a fixed 330 step ran each repetition into the next
+      const runText = 'theo azriel / authentic / 26041992';
+      const runStep = ctx.measureText(runText).width + 26;
       for (let y = 70; y < canvas.height; y += 58) {
-        for (let x = 42; x < canvas.width; x += 330) {
-          const offset = (Math.floor(y / 58) % 2) * 132;
-          ctx.fillText('theo azriel / authentic / 26041992', x - offset, y);
+        const offset = (Math.floor(y / 58) % 2) * (runStep / 2.5);
+        for (let x = 42; x < canvas.width + runStep; x += runStep) {
+          ctx.fillText(runText, x - offset, y);
         }
       }
       ctx.restore();

--- a/apps/portfolio/src/scene.ts
+++ b/apps/portfolio/src/scene.ts
@@ -92,6 +92,8 @@ const WHITE = new THREE.Color(0xffffff);
 // hero looks slightly down-frame at the cloth from a shallow 3/4 angle
 const HERO_CAMERA = [0.86, 0.72, 4.4] as const;
 const HERO_TARGET = [0, -0.14, 0] as const;
+/** how far the line bows between the two clips, world units */
+const WIRE_SAG = 0.045;
 
 function makeColorBackdropTexture() {
   const canvas = document.createElement('canvas');
@@ -260,6 +262,11 @@ export class HoloApp {
     rimB.position.set(4.5, -1.5, -2.5);
     const key = new THREE.DirectionalLight(0xffffff, 0.7);
     key.position.set(1.5, 3, 4);
+    // Deliberately no shadow map. The cloth is ~97% transmissive, and three
+    // builds the transmission backdrop from opaque geometry only — so a
+    // shadow can never show *through* the sheet you can see through, which
+    // is the one place it would need to appear. It also meant re-rendering
+    // a full shadow pass every frame, since the cloth deforms every frame.
     this.scene.add(rimA, rimB, key);
 
     // surface layer (uploaded graphics) + cloth
@@ -384,13 +391,27 @@ export class HoloApp {
     this.clothesline.clear();
 
     const pegs = this.sim.pegPoints();
-    // long enough to run out of frame at any orbit distance we allow
+    const span = Math.abs(pegs[1].x - pegs[0].x) / 2;
+    const y0 = pegs[0].y;
+
+    // A taut wire would be the one thing in frame that gravity ignores, so it
+    // bows under the load it carries: cos² dips it between the clips and
+    // arrives flat and level at each one (zero slope there), which is what a
+    // line reads as when its poles are far outside the frame.
+    const sag = (x: number) => {
+      if (Math.abs(x) >= span) return y0;
+      return y0 - WIRE_SAG * Math.cos((Math.PI * x) / (2 * span)) ** 2;
+    };
+    const points: THREE.Vector3[] = [];
+    for (let i = 0; i <= 96; i++) {
+      // long enough to run out of frame at any orbit distance we allow
+      const x = -30 + (60 * i) / 96;
+      points.push(new THREE.Vector3(x, sag(x), pegs[0].z));
+    }
     const wire = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.008, 0.008, 60, 8),
+      new THREE.TubeGeometry(new THREE.CatmullRomCurve3(points), 96, 0.008, 6, false),
       this.lineMaterial,
     );
-    wire.rotation.z = Math.PI / 2;
-    wire.position.set(0, pegs[0].y, pegs[0].z);
     wire.frustumCulled = false;
     this.clothesline.add(wire);
 
@@ -400,7 +421,7 @@ export class HoloApp {
         this.clipMaterial,
       );
       // sits just in front of the fabric, straddling the wire
-      clip.position.set(peg.x, peg.y + 0.028, peg.z + 0.028);
+      clip.position.set(peg.x, sag(peg.x) + 0.028, peg.z + 0.028);
       this.clothesline.add(clip);
     }
   }


### PR DESCRIPTION
Rebased onto `main` after #4. Two changes remain, both effectively free at runtime.

## 1. The line bows

A taut wire was the one thing left in frame that gravity ignored. It now dips between the clips as `cos²`, which has zero slope where it meets each clip — so it arrives flat and level there, which is how a line reads when its poles are far outside the frame. (A parabola would kick upward past the clips and shoot out of frame.)

`TubeGeometry` along the sampled curve; the clips ride the curve rather than the old flat y. Built once per cloth rebuild, not per frame.

## 2. Print texture overlap — a real bug

The tiling loop stepped a fixed `x += 330`, but `'theo azriel / authentic / 26041992'` measures ~337px at 17px Plex Mono, so every repetition ran ~7px into the next. That was the `2604199theo azriel` mashing visible across the whole cloth. The step now comes from `ctx.measureText`. One-time canvas draw.

## Dropped in the rebase: the thickness fix

This PR previously carried `thickness: 0.24 → 0.02` on the tape preset. #4 landed the identical change, so that commit was skipped during the rebase and `main`'s version is kept — including its comment, which pins the mechanism more precisely than mine did (three draws the sheet's far face into the transmission background when the material is double-sided, so the artwork prints twice, offset).

## Also dropped earlier: shadows

An earlier revision of this PR added a shadow pass. Removed before this rebase, for two reasons — the first fatal:

- **They can't show through the cloth.** The material is `transmission: 0.97`, but three builds the transmission backdrop from **opaque** geometry only, and `ShadowMaterial` is `transparent: true` — so the catcher was excluded from exactly the texture the cloth samples to see through itself. The shadow could only appear *around* the cloth, never through it.
- **They made the page heavier**, which is the opposite of where #4 took the hero.

`dofPass.ts` is byte-identical to `main`; the lighting is unchanged from `main`.

## Verified after the rebase

`tsc -b` and `vite build` clean. Rendered the hero on top of #4's changes: bowing line, clean non-overlapping tiling, no ghost layer, and #4's perf work (half-res bloom, single-buffer MSAA, `transmissionResolutionScale`, resumable settle, gated hover raycast) all intact.

Tuning knob: `WIRE_SAG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)