### PR TITLE
Cut the hero's frame cost by ~40% and unblock the load paint

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -82,7 +82,12 @@ const TAPE_PARAMS: HoloParams = {
     coatRoughness: 0.025,
     sheen: 0,
     transmission: 0.97,
-    thickness: 0.24,
+    // Tape is a film, not a block of glass. thickness sets how far the
+    // refracted ray is displaced, and three draws the sheet's far face into
+    // the transmission background when a transmissive material is
+    // double-sided — so anything but a hair's breadth here prints the artwork
+    // a second time, offset, visible as a ghost layer from behind.
+    thickness: 0.02,
     ior: 1.46,
     opacity: 1,
     bump: 0.32,

--- a/apps/portfolio/src/cloth.ts
+++ b/apps/portfolio/src/cloth.ts
@@ -21,6 +21,10 @@ interface GrabState {
 
 const SUBSTEP = 1 / 120;
 const MAX_SUBSTEPS = 4;
+/** substeps of the opening drape: an overdriven fall, then a relaxation pass */
+const SETTLE_DROP_STEPS = 80;
+const SETTLE_RELAX_STEPS = 50;
+const SETTLE_STEPS = SETTLE_DROP_STEPS + SETTLE_RELAX_STEPS;
 /** fraction of the top edge each peg sits in from its corner */
 const PEG_INSET = 0.1;
 /**
@@ -64,10 +68,10 @@ export class ClothSim {
   private grab: GrabState | null = null;
   private accumulator = 0;
   private time = 0;
-  /** settling is deferred to the first step so a rebuild that gets replaced
-   *  in the same frame (aspect + perf profile both change at startup) pays
-   *  for the drape only once */
-  private pendingSettle = true;
+  /** substeps of the opening drape already run. Settling is deferred to the
+   *  first step so a rebuild that gets replaced in the same frame (aspect +
+   *  perf profile both change at startup) pays for the drape only once */
+  private settleStep = 0;
 
   constructor(
     readonly width: number,
@@ -184,6 +188,11 @@ export class ClothSim {
     return out;
   }
 
+  /** True until the opening drape has finished falling into shape. */
+  get isSettling() {
+    return this.settleStep < SETTLE_STEPS;
+  }
+
   /**
    * Fast-forward the sim so the cloth is already hanging on the first frame
    * instead of dropping into place while the page loads. Wind is off — a
@@ -193,18 +202,27 @@ export class ClothSim {
    * how hard gravity pulls: the first pass overdrives gravity to fall into
    * the drape in a fraction of the steps, and the second relaxes the stretch
    * that shortcut introduces back out at the real strength.
+   *
+   * The full drape is a few hundred milliseconds of solving, so it is
+   * resumable: pass a millisecond budget to spread it across frames instead
+   * of blocking one, or Infinity to finish it here.
    */
-  private settle() {
+  settleWithin(budgetMs: number) {
+    if (!this.isSettling) return;
     const drop: ClothPhysicsParams = {
       viscosity: 0.4,
       stiffness: 0.95,
       iterations: 6,
       smoothing: 0.02,
     };
-    for (let i = 0; i < 80; i++) this.substep(drop, 0, 10);
     const relax: ClothPhysicsParams = { ...drop, viscosity: 0.35, iterations: 12 };
-    for (let i = 0; i < 50; i++) this.substep(relax, 0, 1);
-    this.accumulator = 0;
+    const deadline = performance.now() + budgetMs;
+    do {
+      if (this.settleStep < SETTLE_DROP_STEPS) this.substep(drop, 0, 10);
+      else this.substep(relax, 0, 1);
+      this.settleStep++;
+    } while (this.isSettling && performance.now() < deadline);
+    if (!this.isSettling) this.accumulator = 0;
   }
 
   private computeRestLengths() {
@@ -225,8 +243,8 @@ export class ClothSim {
   reset() {
     this.initPositions();
     this.grab = null;
-    this.settle();
-    this.pendingSettle = false;
+    this.settleStep = 0;
+    this.settleWithin(Infinity);
   }
 
   /** Give a random gentle impulse — a "poke" from nowhere. */
@@ -341,10 +359,8 @@ export class ClothSim {
   }
 
   step(dt: number, params: ClothPhysicsParams) {
-    if (this.pendingSettle) {
-      this.pendingSettle = false;
-      this.settle();
-    }
+    // a caller that has not budgeted for the drape gets all of it at once
+    if (this.isSettling) this.settleWithin(Infinity);
     this.accumulator += Math.min(dt, 0.05);
     let steps = 0;
     while (this.accumulator >= SUBSTEP && steps < MAX_SUBSTEPS) {

--- a/apps/portfolio/src/scene.ts
+++ b/apps/portfolio/src/scene.ts
@@ -85,6 +85,8 @@ const TONE_MAPPINGS: Record<string, THREE.ToneMapping> = {
 
 const CLOTH_LONG_SIDE = 3.6;
 const CLOTH_SEGMENTS = 48;
+/** per-frame slice of the opening drape, while the cloth is still hidden */
+const SETTLE_BUDGET_MS = 8;
 const WHITE = new THREE.Color(0xffffff);
 // the drape hangs symmetrically about x=0 and sags below the line, so the
 // hero looks slightly down-frame at the cloth from a shallow 3/4 angle
@@ -144,12 +146,25 @@ const GrainShader = {
   `,
 };
 
+/**
+ * Bloom is a low-frequency effect by construction, so resolving it at half the
+ * framebuffer is invisible and skips three quarters of the blur's fragment
+ * work. EffectComposer sizes its passes in device pixels.
+ */
+class HalfResBloomPass extends UnrealBloomPass {
+  override setSize(width: number, height: number) {
+    super.setSize(Math.max(1, Math.round(width / 2)), Math.max(1, Math.round(height / 2)));
+  }
+}
+
 export class HoloApp {
   private renderer: THREE.WebGLRenderer;
   private scene: THREE.Scene;
   private camera: THREE.PerspectiveCamera;
   private controls!: OrbitControls;
   private composer: EffectComposer;
+  /** the one composer buffer the scene is rasterized into — see constructor */
+  private msaaTarget: THREE.WebGLRenderTarget;
   private bloomPass: UnrealBloomPass;
   private dofPass: MacroDofPass;
   private grainPass: ShaderPass;
@@ -187,6 +202,9 @@ export class HoloApp {
   private editMode = false;
   private prevUseImage = false;
   private hoverCursor = 'default';
+  /** the pointer moved since the last hover test — see tick() */
+  private hoverDirty = false;
+  private revealPending = false;
   private resizeObserver: ResizeObserver;
   private params: HoloParams | null = null;
   private disposed = false;
@@ -210,6 +228,10 @@ export class HoloApp {
     this.renderer.setSize(width, height);
     this.renderer.toneMapping = THREE.AgXToneMapping;
     this.renderer.toneMappingExposure = 1.1;
+    // A transmissive cloth makes three re-render the scene into a background
+    // buffer — with a full mip chain — every frame. Nothing survives a
+    // refracting sheet at full resolution, so halve it.
+    this.renderer.transmissionResolutionScale = 0.5;
     host.appendChild(this.renderer.domElement);
 
     this.scene = new THREE.Scene();
@@ -293,12 +315,20 @@ export class HoloApp {
       type: THREE.HalfFloatType,
     });
     this.composer = new EffectComposer(this.renderer, rt);
+    // EffectComposer clones that target for its ping-pong partner, but only the
+    // buffer the scene is rasterized into has geometry edges to antialias — the
+    // other one just receives full-screen post output, where multisampling is
+    // bandwidth and a resolve blit spent on nothing. RenderPass draws into
+    // readBuffer, which starts life as renderTarget2; tick() re-pins it every
+    // frame because toggling a pass (DOF) flips the swap parity.
+    this.msaaTarget = this.composer.renderTarget2;
+    this.composer.renderTarget1.samples = 0;
     this.composer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.composer.addPass(new RenderPass(this.scene, this.camera));
     this.dofPass = new MacroDofPass(this.scene, this.camera);
     this.dofPass.enabled = false;
     this.composer.addPass(this.dofPass);
-    this.bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 0.18, 0.85, 1.0);
+    this.bloomPass = new HalfResBloomPass(new THREE.Vector2(width / 2, height / 2), 0.18, 0.85, 1.0);
     this.composer.addPass(this.bloomPass);
     this.composer.addPass(new OutputPass());
     this.grainPass = new ShaderPass(GrainShader);
@@ -509,10 +539,13 @@ export class HoloApp {
     return this.surface.clothImage !== null;
   }
 
-  /** Show the cloth once the app's assets are in place. */
+  /**
+   * Show the cloth once the app's assets are in place — on the first frame
+   * where the opening drape has also finished settling, so it is never seen
+   * mid-fall.
+   */
   reveal() {
-    this.clothMesh.visible = true;
-    this.clothesline.visible = true;
+    this.revealPending = true;
   }
 
   /** Small data-URL preview of an image, cached per element. */
@@ -587,12 +620,10 @@ export class HoloApp {
     this.renderer.setPixelRatio(this.currentPR);
     this.renderer.setSize(w, h);
     this.composer.setPixelRatio(this.currentPR);
-    // MSAA sample count lives on the composer's ping-pong targets; force
-    // reallocation so the new count takes effect
-    this.composer.renderTarget1.samples = samples;
-    this.composer.renderTarget2.samples = samples;
-    this.composer.renderTarget1.dispose();
-    this.composer.renderTarget2.dispose();
+    // MSAA lives on the one target the scene is drawn into; force reallocation
+    // so the new count takes effect
+    this.msaaTarget.samples = samples;
+    this.msaaTarget.dispose();
     this.composer.setSize(w, h);
     if (segs !== this.clothSegments) {
       this.clothSegments = segs;
@@ -778,6 +809,7 @@ export class HoloApp {
     const active = this.grabbing || this.draggingDecal;
     if (active && e.pointerId !== this.grabPointerId) return;
     this.updatePointer(e);
+    this.hoverDirty = true;
     if (this.draggingDecal) {
       const hit = this.raycastCloth();
       const sel = this.surface.selected;
@@ -816,6 +848,8 @@ export class HoloApp {
   };
 
   private onWheel = (e: WheelEvent) => {
+    // zooming slides the cloth under a stationary cursor
+    this.hoverDirty = true;
     if (!this.editMode) return;
     const sel = this.surface.selected;
     if (!sel) return;
@@ -855,10 +889,27 @@ export class HoloApp {
     this.elapsed += dt;
     this.grainPass.uniforms.uTime.value = this.elapsed % 61.7;
 
+    // pin the multisampled buffer as the one RenderPass draws into: a pass
+    // switching its enabled flag mid-session changes how often buffers swap
+    if (this.composer.readBuffer !== this.msaaTarget) this.composer.swapBuffers();
+
     if (this.params) {
-      this.sim.step(dt, this.params.physics);
+      if (this.sim.isSettling && !this.clothMesh.visible) {
+        // The opening drape is a few hundred ms of constraint solving, and
+        // there is nothing on screen yet to spend it on — take it a slice at
+        // a time instead of freezing the page as it paints.
+        this.sim.settleWithin(SETTLE_BUDGET_MS);
+      } else {
+        this.sim.step(dt, this.params.physics);
+      }
       this.clothGeometry.attributes.position.needsUpdate = true;
       this.clothGeometry.computeVertexNormals();
+    }
+
+    if (this.revealPending && !this.sim.isSettling) {
+      this.revealPending = false;
+      this.clothMesh.visible = true;
+      this.clothesline.visible = true;
     }
 
     if (this.params?.render.occlusion) {
@@ -882,9 +933,12 @@ export class HoloApp {
       this.dofPass.setFocus(focusDist);
     }
 
-    // hover cursor feedback (skip while dragging/picking/panning; off on Low)
-    if (!this.grabbing && !this.draggingDecal && !this.pickingFocus && !this.spaceHeld &&
-        this.perfProfile !== 'Low') {
+    // hover cursor feedback (skip while dragging/picking/panning; off on Low).
+    // Only worth a raycast once the pointer has actually moved — the cloth
+    // drifts under a still cursor, but never far enough to change the answer.
+    if (this.hoverDirty && !this.grabbing && !this.draggingDecal && !this.pickingFocus &&
+        !this.spaceHeld && this.perfProfile !== 'Low') {
+      this.hoverDirty = false;
       const hit = this.raycastCloth();
       let cursor = 'default';
       if (hit) {


### PR DESCRIPTION
The hero was GPU-bound past its frame budget at any real fullscreen size. Measured with a `readPixels` fence around `composer.render`, DPR 2:

| viewport | before | after |
|---|---|---|
| 1280×720 | 16.3 ms | **9.8 ms** |
| 1512×945 (14" MBP) | 25.2 ms | **14.9 ms** |
| 1728×1080 (16" MBP) | 32.4 ms | **19.3 ms** |

Plus ~4.7 ms/frame of CPU, and a 194 ms hard freeze on the first frame.

## Where the time was going

Isolated one toggle at a time against the 16.3 ms baseline: MSAA accounted for 8.1 ms, transmission 6.8 ms, bloom 4.2 ms — at `strength: 0.035`, i.e. producing nothing visible. Four fixes, none of which cost image quality.

**MSAA on both composer buffers.** `EffectComposer` clones its render target for the ping-pong partner, so both carried 8× samples. Only the buffer the scene rasterizes into has geometry edges to antialias — the other one just receives full-screen post output, where multisampling is bandwidth plus a resolve blit spent on nothing.

Which buffer gets the geometry isn't fixed: `RenderPass` draws into `readBuffer`, which starts as `renderTarget2`, and toggling a pass (DOF) changes the swap count per frame and flips it. So `tick()` re-pins it rather than hardcoding one. Verified by instrumenting `RenderPass.render` — the scene lands on the multisampled target in both parities.

**Bloom at full resolution**, for an effect that is low-frequency by construction. Halved via a `HalfResBloomPass` subclass, since `EffectComposer` drives `setSize` on resize.

**The transmission background at full resolution.** A transmissive cloth makes three re-render the scene into a backing buffer — with a full mip chain — every frame. Nothing survives a refracting sheet at that detail, so `transmissionResolutionScale = 0.5`. Best ratio of the four: 2.8 ms for a mean pixel delta of 0.004/255.

**`settle()` blocking 194 ms** on the first frame, exactly as the page paints. It's now resumable: `settleWithin(budgetMs)`, fed 8 ms slices by `tick()` while the cloth is still hidden — 182 ms over 20 frames, worst frame 21 ms (cold JIT on `substep`). `reset()` and any rebuild while the cloth is *visible* still pass `Infinity`, so a visible drape is never caught mid-fall.

Also: the hover raycast ran a brute-force pass over 3264 triangles every frame whether or not the pointer had moved. Now gated on pointer movement — 0 raycasts across 10 idle frames, 1 after a move.

## ⚠️ Overlaps with #3

This includes `thickness: 0.24 → 0.02` on the tape preset, which **#3 already fixes identically**. I hit the ghost-layer question independently this session and the perf verification screenshots were taken with it applied, so it's here rather than dropped — but the two PRs will conflict on that line, and on `scene.ts` generally (#3 touches it for the clothesline bow). Whichever lands second wants a rebase; the resolution on the `thickness` line is trivial since both arrive at the same value.

One addition to #3's diagnosis worth recording. #3 attributes the ghost to refraction displacing what's behind the sheet. There's a second mechanism underneath that, which is what puts a copy there to displace in the first place — `renderTransmissionPass` draws the object's **far face** into the transmission background when a transmissive material is `DoubleSide`:

```js
if ( material.side === DoubleSide && object.layers.test( camera.layers ) ) {
  material.side = BackSide;
  renderObject( object, scene, camera, geometry, material, group );
```

Deliberate on three's part — it's how a glass sphere shows its own inner back wall. But this cloth is a zero-thickness sheet with the artwork on both faces, so the "far wall" is the same print. Confirmed two ways: `thickness = 0` collapses the copies together, and `side = BackSide` (skipping the branch, thickness left at 0.24) removes the ghost outright.

That branch is guarded by `extensions.has('WEBGL_multisampled_render_to_texture') === false` — absent in desktop Chrome/Safari, present on many mobile GPUs. So the artifact was platform-dependent, which is a good reason to fix it in the material rather than leave it.

## Behavioural change worth knowing

The cloth's appearance now depends on the animation loop running, where `reveal()` previously made it visible immediately. In a background tab (cmd-clicked link) rAF is paused, so the cloth settles and appears on foregrounding rather than during load. Arguably better, but it is a change.

## Verification

- Full-frame pixel diff vs the previous build: mean 0.17/255, 0.37% of pixels differing by more than 2/255 — most of that from the `thickness` change, which on its own is 0.08%.
- Front and back views screenshotted before and after; ghost confirmed gone, front view unchanged.
- Perf ladder still lands samples on the geometry target only (High 8 / Medium 4 / Low 0), rebuilds the cloth, no flash of unsettled fabric.
- Resize keeps bloom at half the framebuffer (640×360 against 2560×1440).
- `resetCloth()` still settles synchronously and stays visible.
- No console errors. `tsc -b && vite build` clean.

## Not included

Deliberately left out, in rough order of value:

- **Auto-downgrade to a lower perf profile on weak GPUs.** `applyPerfProfile` has the ladder, but nothing ever selects it — all four presets hardcode `performance: 'High'`. This is what still leaves non-Apple hardware around 30fps, and it's the biggest remaining win.
- **Bend-constraint pass split.** They're 3262 of 9872 constraints at strength 0.1 and converge in one pass; solving them on 2 of 14 iterations instead of all 14 should take `sim.step` from 3.9 ms to ~2.8 ms. Estimated, not measured.
- **DPR cap.** 1.75 gives 17.0 → 13.1 ms at 1512×945; 1.5 gives 9.9 ms and comfortable 60fps. Real trade, wants an A/B first.
- **MSAA 8 → 4.** Free on Apple silicon (17.01 vs 16.92 — the cost is the resolve, not the sample count) but a meaningful win on Windows/ANGLE. Left alone since it changes edge quality on hardware I can't test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
