### PR TITLE
Halve the cloth solver's per-frame cost

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -15,7 +15,10 @@ const SILVER_PARAMS: HoloParams = {
     // light air drag, not gel — the drape has to keep swinging on the line
     viscosity: 0.09,
     stiffness: 0.96,
-    iterations: 14,
+    // Gauss-Seidel relaxation converges fast at this stiffness: the last
+    // iterations were spending a full pass over every constraint to move
+    // vertices by amounts too small to see. 8 holds the same drape.
+    iterations: 8,
     smoothing: 0.02,
     grabRadius: 0.32,
   },

--- a/apps/portfolio/src/cloth.ts
+++ b/apps/portfolio/src/cloth.ts
@@ -90,7 +90,13 @@ export class ClothSim {
 
     // Build constraints: structural (1.0), shear (0.8), bend (0.1) — fabric
     // is near-inextensible but bends almost freely, so the bend springs stay
-    // weak or the drape stiffens into sheet metal
+    // weak or the drape stiffens into sheet metal.
+    //
+    // Weak is not the same as removable: they are a third of the constraints
+    // and, being distance pairs like the rest, they carry load. Dropping them
+    // takes the worst stretch from 15% to 21% at the same iteration count,
+    // and clawing that back needs ~20 iterations — which costs more than
+    // keeping them. Measured; do not "optimize" them away again.
     const a: number[] = [];
     const b: number[] = [];
     const mul: number[] = [];


### PR DESCRIPTION
#4 cut the hero's GPU cost, which left the physics as essentially the whole frame. Measured on this build, CPU-only (sim step + normals) came out the same as the full frame: **276,416 constraint solves per frame** of single-threaded JS, ~5.8 ms of a 16.7 ms budget at 60 fps.

## The change

Relaxation iterations **14 → 8**. Gauss-Seidel converges fast at stiffness 0.96 — the last iterations were spending a full pass over every constraint to move vertices by amounts too small to see.

**Cost: 5.80 → 3.51 ms CPU, 6.16 → 3.65 ms full frame.**

The drape is unchanged. Across 8/10/12/14 iterations the resting shape stays within measurement noise:

| iterations | width | lowest point | mean abs z | CPU ms |
|---|---|---|---|---|
| 14 | 3.500 | −1.352 | 0.0614 | 5.65 |
| 12 | 3.489 | −1.353 | 0.0608 | 4.97 |
| 10 | 3.497 | −1.355 | 0.0587 | 4.20 |
| 8 | 3.498 | −1.372 | 0.0596 | 3.43 |

Under a hard drag, worst-case stretch is 400–480% at *every* one of those counts — the grab forces its vertices to the pointer regardless — so interaction doesn't differentiate them either. Screenshots at 8 vs 14 show the same cloth: soft catenary, same fold character.

Resting stretch does rise (mean 0.32% → 0.50%, worst 18% → 32%). It isn't visible, but **10 iterations is the conservative fallback** if that margin feels thin — still a 26% saving.

## What did not work, recorded so it isn't retried

**Dropping the distance-2 bend constraints.** They're a third of the constraint count and look like free savings at strength 0.1. They are not:

- they're distance pairs like any other and carry load — worst stretch went **15% → 21%** at matched iterations
- the drape visibly changed: edges collapsed into hard vertical creases, mean abs z 0.058 → 0.035, reading as crumpled film rather than cloth
- restoring the drape needed ~20 iterations, costing **6.61 ms — worse than the 5.80 ms baseline**

Negative value in both directions. `cloth.ts` now carries a comment with these numbers so the next reader doesn't repeat it.

## Note on the measurements

Taken with a synchronous bench loop in the dev build, driving `tick()` manually because the browser pane here keeps pausing rAF. Absolute values carry roughly ±1 ms of noise; the ratios and the shape metrics are the reliable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)