### PR TITLE
Select a quality profile from the device instead of always High

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -9,8 +9,52 @@ type MaterialVersion =
   | 'holo'
   | 'black';
 
+/**
+ * Pick a quality profile from what the device tells us about itself.
+ *
+ * Without this every visitor got 'High' — DPR 2, 8x MSAA, and a 48-segment
+ * cloth — because nothing ever wrote to `performance`. The hero's two costs
+ * pull in different directions, so both are worth reading:
+ *
+ *  - the cloth solver is single-threaded JS, and its constraint count grows
+ *    with the square of the segment count (48 -> 28 segments is ~9.9k -> 3.4k
+ *    constraints), so core count and memory matter;
+ *  - the material is transmissive with a heavy fragment shader, so cost also
+ *    tracks the pixels actually rasterized — DPR² × viewport.
+ *
+ * Deliberately conservative: it only steps down on clear evidence, since a
+ * wrong guess costs visible fold detail and sharpness. `deviceMemory` is
+ * Chromium-only and `hardwareConcurrency` can be absent, so both fall back to
+ * values that keep a device at 'High' rather than punishing it for being
+ * unmeasurable.
+ */
+function detectPerformanceProfile(): string {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return 'High';
+  const nav = navigator as Navigator & { deviceMemory?: number };
+  const cores = nav.hardwareConcurrency || 8;
+  const memoryGB = nav.deviceMemory ?? 8;
+  const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches ?? false;
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const pixels = window.innerWidth * window.innerHeight * dpr * dpr;
+
+  // Phones and tablets. Medium rather than Low for anything current: with the
+  // render costs cut, the profiles' DPR and MSAA steps are worth ~0.15ms here
+  // while the segment count is worth milliseconds, and Medium already takes
+  // the solver from 9.9k constraints to 5.5k. Low additionally drops to DPR 1
+  // with no MSAA, which is a visibly soft, jagged hero — worth it only on a
+  // device that genuinely cannot keep up.
+  if (coarsePointer) return cores <= 4 || memoryGB <= 4 ? 'Low' : 'Medium';
+  if (cores <= 4 || memoryGB <= 4) return 'Medium';
+  // A retina panel at full screen is fill-bound even on capable hardware:
+  // ~6.5M pixels is where a 1728x1080 DPR-2 window lands.
+  if (pixels > 6.5e6) return 'Medium';
+  return 'High';
+}
+
+const PERFORMANCE_PROFILE = detectPerformanceProfile();
+
 const SILVER_PARAMS: HoloParams = {
-  performance: 'High',
+  performance: PERFORMANCE_PROFILE,
   physics: {
     // light air drag, not gel — the drape has to keep swinging on the line
     viscosity: 0.09,


### PR DESCRIPTION
The profile machinery in `applyPerfProfile` — render scale, MSAA samples, cloth segment count — has never run with anything but `'High'`.

`performance` is set once in `SILVER_PARAMS`, every other preset spreads it, there's no UI to change it, and `src/` contains **no capability detection at all**: no `hardwareConcurrency`, `deviceMemory`, `matchMedia`, or user-agent check anywhere. So every visitor, phones included, got DPR 2, 8× MSAA, and a 48-segment cloth. #4 and #5 optimized the one path everyone was pinned to the most expensive setting of.

## Detection

Reads the two things this hero's cost actually tracks:

- **cores and memory** — the solver is single-threaded JS whose constraint count grows with the *square* of the segment count (48 → 28 segments is 9,872 → 3,406 constraints)
- **DPR² × viewport** — the material is transmissive with a heavy fragment shader

It only steps down on clear evidence. `deviceMemory` is Chromium-only and `hardwareConcurrency` can be absent, so both fall back to values that keep a device at High rather than punishing it for being unmeasurable.

| device | profile | CPU |
|---|---|---|
| iPhone 15 / SE | Medium | ~2.33 ms |
| Mid Android (8GB), iPad Pro | Medium | ~2.33 ms |
| Budget Android (4GB), very old Android | Low | ~1.45 ms |
| MacBook Air M1, gaming desktop 1440p | High | ~4.23 ms |
| MacBook 16" fullscreen, 4K desktop, old Intel laptop | Medium | ~2.33 ms |

## Phones route to Medium, not Low

My first cut sent modern phones to Low. Measuring changed my mind. The GPU share of a frame is now **0.14 ms at Low, 0.35 ms at Medium, 0.29 ms at High** — after #4, the DPR and MSAA steps buy essentially nothing, and the entire saving is the segment count.

Medium already takes the solver from 9,872 constraints to 5,459 (4.23 → 2.33 ms CPU). Low *additionally* drops to DPR 1 with no MSAA, which is a visibly soft, jagged hero — the screenshot at Low shows clear stair-stepping on the silhouette and a broken-looking clothesline. Paying that for ~0.15 ms is a bad trade on a device that can cope. Low is now reserved for hardware that genuinely can't: ≤4 cores or ≤4 GB.

## Verified

- this machine (8 cores, 16 GB, fine pointer, 3.7 MP) still resolves to **High** — desktop quality unchanged
- Medium renders cleanly at a 375×812 viewport with `(pointer: coarse)` matching, which is the path a real phone takes
- all three profiles switch without error; segments, DPR, and MSAA all change as expected

## Caveat worth carrying forward

The per-profile timings come from an M-series Mac. **Fragment cost on a budget mobile GPU can be an order of magnitude worse**, so "DPR barely matters" is not safe to generalize off this hardware. If the mobile hero still struggles, the honest next step is a real-device profile rather than more guessing — and the fix would be raising Low's DPR floor or lowering Medium's, both one-liners in `applyPerfProfile`.

Related: the profile is chosen once at startup and doesn't re-evaluate on resize, so dragging a window onto a 4K display won't re-rank it. Deliberate — re-ranking mid-session rebuilds the cloth and resets the drape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)