### PR TITLE
Reduce the site to the hero, with the email on it

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -356,73 +356,25 @@ export default function App() {
     void renderPrint();
   }, [materialVersion]);
 
-  const scrollToSection = (id: string) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
-  };
-
   return (
     <main className="site is-portfolio" aria-label="Theo Azriel personal site">
       <div id="canvas-host" ref={hostRef} aria-hidden="true" />
 
       <header className="portfolio-header">
         <span className="wordmark">Theo Azriel</span>
-        <nav className="section-nav" aria-label="Page sections">
-          <button type="button" onClick={() => scrollToSection('work')}>Work</button>
-          <button type="button" onClick={() => scrollToSection('about')}>About</button>
+        <nav className="section-nav" aria-label="Site links">
           <a href="https://notes.theoazriel.com">Notes</a>
-          <button type="button" onClick={() => scrollToSection('contact')}>Contact</button>
         </nav>
       </header>
 
       <section className="portfolio-hero" ref={heroRef} aria-labelledby="portfolio-title">
-            <h1 id="portfolio-title" className="sr-only">Theo Azriel</h1>
-            <div className="hero-caption" aria-hidden="true">
-              <p>Designer + engineer</p>
-              <p>Interfaces / systems / experiments</p>
-            </div>
-            <button className="scroll-cue" type="button" onClick={() => scrollToSection('work')}>
-              View work <span aria-hidden="true">↓</span>
-            </button>
-          </section>
-
-          <section className="content-section work-section" id="work" aria-labelledby="work-title">
-            <header className="section-heading">
-              <h2 id="work-title">Selected work</h2>
-              <p>2024—Now</p>
-            </header>
-            <div className="work-list">
-              <article className="work-row">
-                <h3>Interface systems</h3>
-                <p>Product design + engineering</p>
-                <p>Ongoing</p>
-              </article>
-              <article className="work-row">
-                <h3>Applied experiments</h3>
-                <p>Prototypes + research</p>
-                <p>Archive</p>
-              </article>
-            </div>
-          </section>
-
-          <section className="content-section about-section" id="about" aria-labelledby="about-title">
-            <div className="section-heading">
-              <h2 id="about-title">About</h2>
-              <p>Hong Kong</p>
-            </div>
-            <p className="about-copy">
-              I design and build interfaces, tools, and systems. My work connects product design,
-              software engineering, and focused experiments.
-            </p>
-          </section>
-
-          <footer className="content-section contact-section" id="contact">
-            <p>Start a conversation</p>
-            <a href="mailto:theo.azriel@icloud.com">theo.azriel@icloud.com</a>
-            <div className="footer-line">
-              <span>Theo Azriel</span>
-              <span>© 2026</span>
-            </div>
-          </footer>
+        <h1 id="portfolio-title" className="sr-only">Theo Azriel</h1>
+        <div className="hero-caption" aria-hidden="true">
+          <p>Designer + engineer</p>
+          <p>Interfaces / systems / experiments</p>
+        </div>
+        <a className="hero-email" href="mailto:theo.azriel@icloud.com">theo.azriel@icloud.com</a>
+      </section>
     </main>
   );
 }

--- a/apps/portfolio/src/site.css
+++ b/apps/portfolio/src/site.css
@@ -91,7 +91,6 @@ a {
   gap: 18px;
 }
 
-.section-nav button,
 .section-nav a {
   padding: 0;
   border: 0;
@@ -102,13 +101,11 @@ a {
   cursor: pointer;
 }
 
-.section-nav button:hover,
 .section-nav a:hover,
 .hero-email:hover {
   color: #777;
 }
 
-.section-nav button:focus-visible,
 .section-nav a:focus-visible,
 .hero-email:focus-visible {
   outline: 1px solid #090909;

--- a/apps/portfolio/src/site.css
+++ b/apps/portfolio/src/site.css
@@ -92,8 +92,7 @@ a {
 }
 
 .section-nav button,
-.section-nav a,
-.scroll-cue {
+.section-nav a {
   padding: 0;
   border: 0;
   color: inherit;
@@ -105,14 +104,13 @@ a {
 
 .section-nav button:hover,
 .section-nav a:hover,
-.scroll-cue:hover {
+.hero-email:hover {
   color: #777;
 }
 
 .section-nav button:focus-visible,
 .section-nav a:focus-visible,
-.scroll-cue:focus-visible,
-.contact-section a:focus-visible {
+.hero-email:focus-visible {
   outline: 1px solid #090909;
   outline-offset: 4px;
 }
@@ -126,7 +124,7 @@ a {
 }
 
 .hero-caption,
-.scroll-cue {
+.hero-email {
   position: absolute;
   bottom: 20px;
   z-index: 4;
@@ -145,134 +143,16 @@ a {
   margin: 0;
 }
 
-.scroll-cue {
+/* the only call to action left on the page, so it keeps an underline the
+   nav links do without — sized to sit opposite the caption, not compete
+   with the cloth */
+.hero-email {
   right: 19px;
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
   pointer-events: auto;
-}
-
-.content-section {
-  position: relative;
-  z-index: 3;
-  padding: 92px 20px;
-  border-top: 1px solid #cfcfcf;
-  background: #fff;
-}
-
-.section-heading {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 74px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 11px;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.section-heading h2,
-.section-heading p {
-  margin: 0;
-  font: inherit;
-}
-
-.work-section {
-  min-height: 100svh;
-}
-
-.work-list {
-  border-top: 1px solid #090909;
-}
-
-.work-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(180px, 0.75fr) auto;
-  gap: 28px;
-  align-items: baseline;
-  min-height: 142px;
-  padding: 25px 0;
-  border-bottom: 1px solid #090909;
-}
-
-.work-row h3,
-.work-row p {
-  margin: 0;
-}
-
-.work-row h3 {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: clamp(34px, 5.2vw, 78px);
-  font-weight: 600;
-  line-height: 0.92;
-  letter-spacing: -0.055em;
-  text-transform: uppercase;
-}
-
-.work-row p {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 10px;
-  line-height: 1.4;
-  text-transform: uppercase;
-}
-
-.about-section {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.4fr) minmax(0, 1fr);
-  gap: 8vw;
-  min-height: 92svh;
-}
-
-.about-section .section-heading {
-  display: block;
-  margin: 0;
-}
-
-.about-section .section-heading p {
-  margin-top: 8px;
-  color: #777;
-}
-
-.about-copy {
-  max-width: 970px;
-  margin: 0;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: clamp(38px, 5.8vw, 86px);
-  font-weight: 600;
-  line-height: 0.98;
-  letter-spacing: -0.055em;
-  text-transform: uppercase;
-}
-
-.contact-section {
-  display: flex;
-  flex-direction: column;
-  min-height: 78svh;
-  padding-top: 26px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
-.contact-section > p {
-  margin: 0 0 80px;
-}
-
-.contact-section > a {
-  align-self: flex-start;
-  color: #090909;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: clamp(39px, 7.5vw, 112px);
-  font-weight: 600;
-  line-height: 0.9;
-  letter-spacing: -0.055em;
-  text-decoration-thickness: 0.05em;
-  text-underline-offset: 0.08em;
-  text-transform: lowercase;
-}
-
-.footer-line {
-  display: flex;
-  justify-content: space-between;
-  margin-top: auto;
-  padding-top: 80px;
 }
 
 .sr-only {
@@ -288,72 +168,23 @@ a {
 }
 
 @media (max-width: 680px) {
-  .portfolio-header {
-    right: auto;
-  }
-
-  .section-nav {
-    display: none;
-  }
-
+  /* Opposite corners collide once the viewport is narrow, and the caption
+     wraps to a variable number of lines, so a fixed offset cannot clear it.
+     Stack both in the hero's own flow instead, anchored bottom-left. The
+     sr-only h1 stays absolute, so it does not join the column. */
   .portfolio-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
+    gap: 12px;
     min-height: 560px;
+    padding: 0 15px 20px;
   }
 
-  .hero-caption {
-    max-width: 190px;
-  }
-
-  .content-section {
-    padding: 68px 15px;
-  }
-
-  .section-heading {
-    margin-bottom: 52px;
-  }
-
-  .work-row {
-    grid-template-columns: 1fr auto;
-    gap: 10px;
-    min-height: 116px;
-    padding: 20px 0;
-  }
-
-  .work-row h3 {
-    grid-column: 1 / -1;
-    font-size: clamp(37px, 12vw, 58px);
-  }
-
-  .work-row p:last-child {
-    text-align: right;
-  }
-
-  .about-section {
-    display: block;
-    min-height: 86svh;
-  }
-
-  .about-section .section-heading {
-    margin-bottom: 74px;
-  }
-
-  .about-copy {
-    font-size: clamp(39px, 12vw, 60px);
-  }
-
-  .contact-section {
-    min-height: 68svh;
-  }
-
-  .contact-section > a {
+  .hero-caption,
+  .hero-email {
+    position: static;
     max-width: 100%;
-    overflow-wrap: anywhere;
-    font-size: clamp(35px, 11vw, 52px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
   }
 }


### PR DESCRIPTION
The site is now one screen: the cloth, the caption, and a way to get in touch. Selected work, About, and the contact footer are gone; the email moves out of the footer onto the hero, opposite the caption, in the slot the "View work" cue occupied.

## What else had to go

Removing three sections left several things pointing at nothing:

- **Work, About and Contact nav items** all scrolled to anchors that no longer exist. Notes is the only link left, and the nav's label changes from "Page sections" to "Site links" to match what it now is.
- **`scrollToSection`** had no callers.
- **The `prefers-reduced-motion` rule** guarding `scroll-behavior` — nothing scrolls now, and it was setting the property's initial value regardless.
- **`.work-*`, `.contact-section`, `.footer-line`, `.content-section`, `.section-heading`, `.about-*`, `.scroll-cue`** rule blocks. CSS drops from 4.93 kB to 2.63 kB.

## Two judgment calls

**The nav is no longer hidden on mobile.** `.section-nav { display: none }` below 680px existed because four items wouldn't fit beside the wordmark. One fits — and hiding it now would leave mobile with no navigation at all, since there's no longer a footer to scroll to. Wordmark ends at 97px, nav starts at 321px on a 375px viewport.

**The email is caption-scale, not display-scale.** In the footer it was `clamp(39px, 7.5vw, 112px)`. On the hero it takes the same 10px uppercase treatment as the caption it sits opposite — at display size it would fight the cloth for the frame. It keeps an underline, which the nav links do without, since it's the only call to action on the page.

## Mobile layout

Below 680px the hero becomes a bottom-anchored flex column rather than placing caption and email in opposite corners. Opposite corners collide on narrow viewports, and my first attempt at a fixed vertical offset overlapped by 7px at 375px — the caption wraps to a variable number of lines, so no fixed offset clears it. The `sr-only` h1 stays absolutely positioned, so it doesn't join the column.

This also drops the caption's `max-width: 190px`, which only existed to keep it clear of the scroll cue. It now sets in two clean lines instead of three cramped ones.

## Verification

Checked at 1280×800, 375×812 and 320×640:

- No overlap between caption and email (12px gap, 20px bottom inset on mobile).
- No overlap between wordmark and nav; nav within the viewport.
- No horizontal overflow at any width.
- Desktop rules don't leak past the breakpoint — hero back to `display: block`, email `position: absolute; right: 19px`.
- Page height equals viewport height; nothing scrolls.
- `mailto:theo.azriel@icloud.com` intact.
- No console errors. `tsc -b && vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
