### PR TITLE
Drop the quote from the print

### DIFF
--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { HoloApp, type HoloParams } from './scene.ts';
 
-const STATIC_QUOTE = 'Useful things do not need to shout.';
 const A4_LANDSCAPE_ASPECT = Math.SQRT2;
 
 type MaterialVersion =
@@ -298,9 +297,11 @@ export default function App() {
 
     const request = ++textureRequestRef.current;
     const renderPrint = async () => {
+      // both faces must be resident before drawing: the tiling step below is
+      // derived from measureText, which reports fallback metrics until then
       await Promise.all([
         document.fonts.load('600 190px "IBM Plex Mono"'),
-        document.fonts.load('400 28px "IBM Plex Mono"'),
+        document.fonts.load('400 17px "IBM Plex Mono"'),
       ]);
       if (textureRequestRef.current !== request || appRef.current !== app) return;
 
@@ -338,9 +339,6 @@ export default function App() {
       ctx.font = '600 190px "IBM Plex Mono", monospace';
       ctx.fillText('theo', printLeft, 340);
       ctx.fillText('azriel', printLeft, 550);
-
-      ctx.font = '400 28px "IBM Plex Mono", monospace';
-      ctx.fillText(`“${STATIC_QUOTE.toLowerCase()}”`, printLeft, 770, 1120);
 
       drawBarcode(ctx, printLeft, 890, 430, 70, '260419920104', inkColor);
 


### PR DESCRIPTION
Removes "useful things do not need to shout" from the cloth's printed artwork, leaving the name and the barcode.

## The preload had to move with it

`document.fonts.load('400 28px "IBM Plex Mono"')` existed for the quote — 28px was its size. But it was also the only place the **regular** face was named, and that face still sets the tiled background text and the barcode label.

The tiling loop derives its step from `ctx.measureText`, which returns fallback metrics until the face is resident. For this string that's 346.8px with Plex versus 348.0px with the fallback — enough to shift the repetition spacing and reintroduce the overlap [#3](https://github.com/kmakr/personal/pull/3) fixed. It would only have shown on cold loads, where the face hadn't been fetched yet, which is the kind of thing that survives local testing.

So the preload is repointed at `400 17px`, the size actually in use, with a comment recording why the await is load-bearing.

## Verification

- Both faces confirmed resident before the draw; tiling step 372.8px, no overlap in the render.
- Print renders completely — name and barcode present, decal count 1, so `renderPrint` runs to the end.
- `STATIC_QUOTE` and "shout" absent from both the served dev module and the production bundle.
- Build clean.

A stale `STATIC_QUOTE is not defined` error lingers in the browser console from a mid-edit HMR module (`App.tsx?t=1786375484261`); the console buffer isn't cleared on navigation. Not present in current code — see the bundle/module greps above.

## One thing left alone

The quote sat at y=770, between "azriel" (baseline 550) and the barcode (y=890), so the print now has a band of empty space there. It reads as deliberate whitespace rather than a hole, and the ask was only to remove the text. Moving the barcode up to ~700 would close it if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
