### PR TITLE
Render at native DPR within a pixel budget, not under a flat cap

### DIFF
--- a/apps/portfolio/src/scene.ts
+++ b/apps/portfolio/src/scene.ts
@@ -633,11 +633,22 @@ export class HoloApp {
   private applyPerfProfile(profile: string) {
     this.perfProfile = profile;
     const dpr = window.devicePixelRatio;
-    this.currentPR = profile === 'Low' ? 1 : profile === 'Medium' ? Math.min(dpr, 1.5) : Math.min(dpr, 2);
-    const samples = profile === 'Low' ? 0 : profile === 'Medium' ? 4 : 8;
-    const segs = profile === 'Low' ? 28 : profile === 'Medium' ? 36 : 48;
     const w = this.host.clientWidth || window.innerWidth;
     const h = this.host.clientHeight || window.innerHeight;
+    // Render scale is a pixel budget, not a flat DPR cap. A cap tuned for
+    // desktops (where DPR² × a large viewport explodes) also throttled
+    // phones, where the viewport is so small that even native DPR 3 costs
+    // ~3MP — half of a desktop High — while the 3x panel makes the resulting
+    // upscale blur most visible. Budget instead: render at native DPR until
+    // that would exceed the profile's device-pixel allowance, then scale
+    // down to fit it.
+    const budget = profile === 'Low' ? 1.6e6 : profile === 'Medium' ? 3.6e6 : 7.2e6;
+    const fit = Math.sqrt(budget / (w * h));
+    // floored at 1: never render below CSS resolution — a 4K DPR-1 desktop
+    // over budget gets the old full-res behavior, not fresh blur
+    this.currentPR = Math.max(1, Math.min(dpr, 3, fit));
+    const samples = profile === 'Low' ? 0 : profile === 'Medium' ? 4 : 8;
+    const segs = profile === 'Low' ? 28 : profile === 'Medium' ? 36 : 48;
     this.renderer.setPixelRatio(this.currentPR);
     this.renderer.setSize(w, h);
     this.composer.setPixelRatio(this.currentPR);


### PR DESCRIPTION
Fixes the blurry hero on phones.

## Why it was blurry

#6 routes phones to Medium, and Medium capped the render at **DPR 1.5**. On a 3× phone panel the canvas gets upscaled 2× — every rendered pixel smeared across four physical ones. The flat caps were tuned for desktops, where DPR² × a large viewport explodes; but a 393×852 phone viewport at full DPR 3 only costs **3.0 MP, about half of a desktop High (5.7 MP)**. The caps throttled exactly the screens where high DPR is cheapest and softness is most visible.

## The change

Each profile grants a device-pixel budget — Low 1.6 MP, Medium 3.6 MP, High 7.2 MP — and the renderer runs at native DPR (up to 3) unless that would exceed the budget, scaling down just enough to fit when it would. Floored at CSS resolution so an over-budget low-DPR display (a 4K DPR-1 desktop is 8.3 MP at Medium) keeps its old full-res behavior instead of gaining fresh blur.

MSAA and cloth segments per profile are unchanged.

## Measured

| case | before | after |
|---|---|---|
| desktop High, 1280×720 @ DPR 2 | PR 2, 3.69 MP | PR 2, 3.69 MP — unchanged |
| mobile-emulated Medium, 375×812 @ DPR 2 | PR 1.5 (upscaled) | **PR 2 native, 1.22 MP, visibly sharp** |
| DPR-3 iPhone, computed | PR 1.5 (2× upscale) | **PR 3 native, 2.74 MP** |

Screenshots: desktop identical; the mobile viewport renders sharp print and a clean silhouette.

Same caveat as #6: all measurements are from an M-series Mac and browser emulation. The budget numbers are sized so a phone's native render stays well under what desktops already pay, but a real-device check remains the honest confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)