### PR TITLE
Add a CMS at notes.theoazriel.com/admin

### DIFF
--- a/.github/workflows/deploy-cms-auth.yml
+++ b/.github/workflows/deploy-cms-auth.yml
@@ -1,0 +1,40 @@
+name: Deploy cms-auth
+
+# The GitHub OAuth relay Worker behind the notes CMS login. Same shape as the
+# other two deploy workflows, minus a build step — it's a single JS file with
+# nothing to compile. Its GITHUB_CLIENT_SECRET lives at Cloudflare and is
+# untouched by deploys.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/cms-auth/**'
+      - 'package-lock.json'
+      - '.github/workflows/deploy-cms-auth.yml'
+      - '.nvmrc'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-cms-auth
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run deploy:cms-auth
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/cms-auth/package.json
+++ b/apps/cms-auth/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@theo/cms-auth",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.118.0"
+  }
+}

--- a/apps/cms-auth/src/index.js
+++ b/apps/cms-auth/src/index.js
@@ -1,0 +1,121 @@
+/**
+ * GitHub OAuth relay for the notes CMS.
+ *
+ * Why this exists: the admin page (Sveltia CMS) is static files with no
+ * server, but GitHub's OAuth login requires a server-side secret to finish
+ * the handshake — a browser page can never hold the client secret. This
+ * Worker is that server. It does exactly two things:
+ *
+ *   GET /auth      → send the visitor to GitHub's login page
+ *   GET /callback  → trade GitHub's one-time code for an access token and
+ *                    hand the token back to the CMS popup window
+ *
+ * The token never touches this Worker's storage — it goes straight to the
+ * CMS in the browser, which uses it to commit Markdown to the repo. Who may
+ * publish is decided by GitHub (write access to the repo), not by anything
+ * here.
+ *
+ * Speaks the Decap/Netlify OAuth popup protocol, which Sveltia implements.
+ */
+
+/** Only these sites may receive a token from the popup handshake. */
+const ALLOWED_ORIGINS = ['https://notes.theoazriel.com'];
+
+const GITHUB_AUTHORIZE = 'https://github.com/login/oauth/authorize';
+const GITHUB_TOKEN = 'https://github.com/login/oauth/access_token';
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (request.method !== 'GET') return new Response('Method not allowed', { status: 405 });
+    if (url.pathname === '/auth') return startLogin(url, env);
+    if (url.pathname === '/callback') return finishLogin(request, url, env);
+    return new Response('CMS OAuth relay — nothing to browse here.', { status: 404 });
+  },
+};
+
+/** Step 1: bounce the visitor to GitHub, carrying an anti-forgery state. */
+function startLogin(url, env) {
+  if (!env.GITHUB_CLIENT_ID) {
+    return popupError('The relay is not configured yet: GITHUB_CLIENT_ID is empty.');
+  }
+  // random state ties the /callback to this /auth — a forged callback
+  // without the matching cookie is rejected
+  const state = crypto.randomUUID();
+  const to = new URL(GITHUB_AUTHORIZE);
+  to.searchParams.set('client_id', env.GITHUB_CLIENT_ID);
+  to.searchParams.set('scope', 'repo');
+  to.searchParams.set('state', state);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: to.toString(),
+      'Set-Cookie': `oauth_state=${state}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=600`,
+    },
+  });
+}
+
+/** Step 2: verify state, swap the code for a token, hand it to the popup. */
+async function finishLogin(request, url, env) {
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const cookieState = (request.headers.get('Cookie') ?? '')
+    .match(/(?:^|;\s*)oauth_state=([^;]+)/)?.[1];
+
+  if (!code) return popupError('GitHub sent no code.');
+  if (!state || state !== cookieState) {
+    return popupError('State mismatch — start the login again from the CMS.');
+  }
+  if (!env.GITHUB_CLIENT_SECRET) {
+    return popupError('The relay is not configured yet: GITHUB_CLIENT_SECRET is not set.');
+  }
+
+  const res = await fetch(GITHUB_TOKEN, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({
+      client_id: env.GITHUB_CLIENT_ID,
+      client_secret: env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!data.access_token) {
+    return popupError(`GitHub refused the exchange: ${data.error_description ?? 'no token returned'}`);
+  }
+  return popupResult('success', { token: data.access_token, provider: 'github' });
+}
+
+/**
+ * The Decap popup handshake, verbatim:
+ *  1. this popup posts "authorizing:github" to the window that opened it
+ *  2. the CMS replies with any message, revealing its origin
+ *  3. if that origin is allowed, the popup posts the result and closes
+ */
+function popupResult(status, payload) {
+  const message = `authorization:github:${status}:${JSON.stringify(payload)}`;
+  const body = `<!doctype html><meta charset="utf-8"><title>Signing in…</title><script>
+    (function () {
+      var allowed = ${JSON.stringify(ALLOWED_ORIGINS)};
+      if (!window.opener) { document.body.textContent = 'Open this from the CMS.'; return; }
+      window.addEventListener('message', function reply(e) {
+        if (!allowed.includes(e.origin)) return;
+        window.removeEventListener('message', reply);
+        window.opener.postMessage(${JSON.stringify(message)}, e.origin);
+        window.close();
+      });
+      window.opener.postMessage('authorizing:github', '*');
+    })();
+  </script>`;
+  return new Response(body, {
+    // the one-time state cookie is spent either way
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Set-Cookie': 'oauth_state=; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=0',
+    },
+  });
+}
+
+function popupError(reason) {
+  return popupResult('error', { error: reason });
+}

--- a/apps/cms-auth/wrangler.toml
+++ b/apps/cms-auth/wrangler.toml
@@ -14,6 +14,7 @@ compatibility_date = "2026-08-11"
 workers_dev = true
 
 [vars]
-# from the GitHub OAuth app (github.com → Settings → Developer settings);
-# empty until the app is created — the relay returns a clear error meanwhile
-GITHUB_CLIENT_ID = ""
+# from the GitHub OAuth app "notes.theoazriel.com" (github.com → Settings →
+# Developer settings). This is the app's public identifier, not a secret —
+# the secret half never enters git: wrangler secret put GITHUB_CLIENT_SECRET
+GITHUB_CLIENT_ID = "Ov23ctPO0EsCTfeji3Vp"

--- a/apps/cms-auth/wrangler.toml
+++ b/apps/cms-auth/wrangler.toml
@@ -1,0 +1,19 @@
+# GitHub OAuth relay for the notes CMS — see src/index.js for what and why.
+#
+# Unlike the other two Workers this one has a `main`: it runs code. It serves
+# no files and has no custom domain; the CMS reaches it on its workers.dev URL.
+#
+# Configuration lives in two places:
+#   GITHUB_CLIENT_ID     — public identifier, plain var below
+#   GITHUB_CLIENT_SECRET — real secret, stored at Cloudflare, never in git:
+#                          npx wrangler secret put GITHUB_CLIENT_SECRET
+
+name = "theo-cms-auth"
+main = "src/index.js"
+compatibility_date = "2026-08-11"
+workers_dev = true
+
+[vars]
+# from the GitHub OAuth app (github.com → Settings → Developer settings);
+# empty until the app is created — the relay returns a clear error meanwhile
+GITHUB_CLIENT_ID = ""

--- a/apps/notes/public/admin/config.yml
+++ b/apps/notes/public/admin/config.yml
@@ -1,0 +1,42 @@
+# Sveltia CMS configuration for the notes blog.
+#
+# The fields below mirror the schema in apps/notes/src/content.config.ts —
+# if you change one, change the other, or the build will reject what the
+# CMS writes (that rejection is the safety net, not a bug).
+
+backend:
+  name: github
+  repo: kmakr/personal
+  branch: main
+  # the cms-auth Worker that completes GitHub's login handshake
+  base_url: https://theo-cms-auth.theoazrie.workers.dev
+
+# where uploaded images land in the repo, and the URL they get on the site
+media_folder: apps/notes/public/images
+public_folder: /images
+
+collections:
+  - name: notes
+    label: Notes
+    folder: apps/notes/src/content/notes
+    create: true
+    extension: md
+    slug: '{{slug}}'
+    fields:
+      - { label: Title, name: title, widget: string }
+      - label: Date
+        name: date
+        widget: datetime
+        format: 'YYYY-MM-DD'
+        time_format: false
+      - { label: Summary, name: summary, widget: string }
+      - label: Tags
+        name: tags
+        widget: list
+        required: false
+        default: []
+      - label: Draft
+        name: draft
+        widget: boolean
+        default: false
+        hint: 'Drafts are committed to the repo but never published to the site.'

--- a/apps/notes/public/admin/index.html
+++ b/apps/notes/public/admin/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- keep the admin door out of search results -->
+    <meta name="robots" content="noindex" />
+    <title>Notes admin</title>
+  </head>
+  <body>
+    <!-- Sveltia CMS: the whole editor is this one script. It reads
+         ./config.yml, signs in through the cms-auth Worker, and commits
+         Markdown straight to the GitHub repo — no server here. -->
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,13 @@
         "apps/*"
       ]
     },
+    "apps/cms-auth": {
+      "name": "@theo/cms-auth",
+      "version": "1.0.0",
+      "devDependencies": {
+        "wrangler": "^4.118.0"
+      }
+    },
     "apps/notes": {
       "name": "@theo/notes",
       "version": "1.0.0",
@@ -552,9 +559,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,9 +574,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -590,9 +591,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -608,9 +606,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1195,9 +1190,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1202,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1227,9 +1216,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1242,9 +1228,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2046,6 +2029,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2068,6 +2052,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2087,6 +2072,7 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
       "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2109,6 +2095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2125,6 +2112,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2141,9 +2129,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2160,9 +2146,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2179,9 +2163,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2198,9 +2180,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2217,9 +2197,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2236,9 +2214,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2255,9 +2231,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2274,9 +2248,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2293,9 +2265,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2318,9 +2288,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2343,9 +2311,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2368,9 +2334,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2393,9 +2357,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2418,9 +2380,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2443,9 +2403,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2468,9 +2426,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2490,6 +2446,7 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
       "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2509,6 +2466,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -2528,6 +2486,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2547,6 +2506,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2566,6 +2526,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2791,9 +2752,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2809,9 +2767,6 @@
       "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2829,9 +2784,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2847,9 +2799,6 @@
       "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2867,9 +2816,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2885,9 +2831,6 @@
       "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2988,6 +2931,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3001,6 +2945,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3014,6 +2959,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3027,6 +2973,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3040,6 +2987,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3053,6 +3001,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3066,6 +3015,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3079,6 +3029,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3092,6 +3043,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3105,6 +3057,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3118,6 +3071,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3131,6 +3085,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3144,6 +3099,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3157,6 +3113,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3170,6 +3127,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3183,6 +3141,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,6 +3155,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3209,6 +3169,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,6 +3183,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,6 +3197,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3248,6 +3211,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3261,6 +3225,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3274,6 +3239,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3287,6 +3253,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3300,6 +3267,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3358,6 +3326,10 @@
       "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@theo/cms-auth": {
+      "resolved": "apps/cms-auth",
+      "link": true
     },
     "node_modules/@theo/notes": {
       "resolved": "apps/notes",
@@ -5034,9 +5006,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5056,9 +5025,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5080,9 +5046,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5102,9 +5065,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:portfolio": "npm run dev --workspace @theo/portfolio",
     "dev:notes": "npm run dev --workspace @theo/notes",
     "deploy:portfolio": "npm run deploy --workspace @theo/portfolio",
-    "deploy:notes": "npm run deploy --workspace @theo/notes"
+    "deploy:notes": "npm run deploy --workspace @theo/notes",
+    "deploy:cms-auth": "npm run deploy --workspace @theo/cms-auth"
   }
 }


### PR DESCRIPTION
A real editor at **notes.theoazriel.com/admin** — write, upload images, toggle drafts, hit Publish. Publishing is a git commit to `main`; the existing deploy-notes workflow does the rest. Works from a phone.

## How the pieces fit

```text
you → /admin (Sveltia CMS, two static files on the existing notes Worker)
        ↓ login
      cms-auth Worker (new, third Worker — GitHub's OAuth handshake needs a
        server-side secret no browser page may hold; this is that server)
        ↓ token, straight to your browser — the Worker stores nothing
      CMS commits Markdown to kmakr/personal on GitHub
        ↓ push to main
      deploy-notes workflow builds + ships, same as a hand-written note
```

**Who can publish is decided by GitHub** — write access to this repo — not by the relay. The relay only authenticates. Guards on it: only `https://notes.theoazriel.com` may receive a token (exact-origin check in the popup handshake), a state cookie ties each callback to the login that started it, POST is rejected, and errors surface inside the CMS rather than as dead pages.

## What's in the diff

- `apps/cms-auth/` — the relay: ~100-line Worker, two routes, heavily commented. This one *does* have a `main` in its wrangler.toml — it's the first of the three Workers that runs code.
- `apps/notes/public/admin/` — `index.html` (loads Sveltia, `noindex`) and `config.yml` (fields mirror `content.config.ts` exactly; if they ever drift, `astro check` fails the deploy instead of shipping a broken note — the safety net from the onboarding guide, doing its job).
- `.github/workflows/deploy-cms-auth.yml` — same shape as the other two, minus a build step.
- `package.json` / lockfile — new workspace `@theo/cms-auth`. The lockfile also carries the same npm metadata churn seen before (libc hints removed); unavoidable this time since the workspace entry is required. CI's `npm ci` has already proven tolerant of both states.

## Already verified

- Relay deployed at `https://theo-cms-auth.theoazrie.workers.dev` (matches `config.yml`'s `base_url`): `/` 404s, POST 405s, unconfigured `/auth` reports itself cleanly through the popup protocol, forged `/callback` rejected on state mismatch.
- `astro check && astro build` passes; `dist/admin/` contains both files.
- CMS config and workflow parse; field list `title, date, summary, tags, draft` matches the Zod schema field for field.

## ⚠️ Two manual steps after merge (account actions — yours)

1. **Create the GitHub OAuth app**: github.com → Settings → Developer settings → OAuth Apps → New.
   - Homepage: `https://notes.theoazriel.com`
   - **Authorization callback URL: `https://theo-cms-auth.theoazrie.workers.dev/callback`** (must be exact)
   - Then paste the **Client ID** (public, not a secret) into `apps/cms-auth/wrangler.toml` — or tell Claude the ID and it'll do it.
2. **Set the secret** (don't paste it anywhere else):
   ```bash
   cd apps/cms-auth && npx wrangler secret put GITHUB_CLIENT_SECRET
   ```

Until both are done, `/admin` loads but login fails with a clear message. Nothing is exposed in the meantime — there's no secret anywhere in this diff.

## Deliberately not included

**Cloudflare Access in front of `/admin`.** It's cosmetic here (hides the door; GitHub is the lock) and it's a dashboard/Zero-Trust signup action that shouldn't block publishing. Can be added any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
