### PR TITLE
Give the CMS a content editor, and undo the test save

### DIFF
--- a/apps/notes/public/admin/config.yml
+++ b/apps/notes/public/admin/config.yml
@@ -40,3 +40,7 @@ collections:
         widget: boolean
         default: false
         hint: 'Drafts are committed to the repo but never published to the site.'
+      # `body` is the one reserved field name: it is not frontmatter, it IS
+      # the Markdown below the --- fence. Omit it and the CMS shows no
+      # content editor at all — every other field still saves fine.
+      - { label: Body, name: body, widget: markdown }

--- a/apps/notes/src/content/notes/clear-tape.md
+++ b/apps/notes/src/content/notes/clear-tape.md
@@ -1,9 +1,8 @@
 ---
-title: This is a sample post
+title: "Clear tape is a surface"
 date: 2026-08-05
-summary: A short record of the material study behind this site.
-tags:
-  - test
+summary: "A short record of the material study behind this site."
+tags: ["design", "webgl"]
 draft: false
 ---
 


### PR DESCRIPTION
The CMS showed Title/Date/Summary/Tags/Draft but **no content editor** — because `config.yml` declared only frontmatter fields, and the Markdown body is a *reserved* field named `body` that must be declared like any other. One line adds it (`widget: markdown`).

Found via a live test save, which also went to production: the real **clear-tape** note was retitled "This is a sample post" with tag `test`. Sveltia preserved the undeclared body, so nothing was lost — this PR also restores the note's title and tags byte-for-byte to their pre-test state.

Merging deploys the fixed `/admin` and the restored note in one go (~40 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)