### PR TITLE
Always render the blog light

### DIFF
--- a/apps/notes/src/styles/global.css
+++ b/apps/notes/src/styles/global.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
   --width: 720px;
   --font-main: Verdana, sans-serif;
   --font-secondary: Verdana, sans-serif;
@@ -12,19 +12,6 @@
   --code-background-color: #f2f2f2;
   --code-color: #222;
   --blockquote-color: #222;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background-color: #01242e;
-    --heading-color: #eee;
-    --text-color: #ddd;
-    --link-color: #8cc2dd;
-    --visited-color: #8b6fcb;
-    --code-background-color: #000;
-    --code-color: #ddd;
-    --blockquote-color: #ccc;
-  }
 }
 
 * {


### PR DESCRIPTION
Removes the dark palette from notes.theoazriel.com: the `prefers-color-scheme: dark` variable block is gone and `:root` now declares `color-scheme: light`, which also stops the browser from darkening form controls and scrollbars on its own.

Verified locally with the browser forced to dark mode: white background, dark text, computed `color-scheme: light`. No dark-mode rules remain anywhere under `apps/notes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)