### PR TITLE
Draft previews and the CMS image upload folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ npm run build
 ## Publish a note
 
 1. Add a Markdown file to `apps/notes/src/content/notes`.
-2. Set `draft: false` in its frontmatter.
-3. Commit and push the file.
-4. Cloudflare builds and deploys the notes site.
+2. While `draft: true`, the note renders only at the unlisted, noindex
+   `notes.theoazriel.com/drafts/<slug>` for proofreading.
+3. Set `draft: false` in its frontmatter.
+4. Commit and push the file.
+5. Cloudflare builds and deploys the notes site.
 
 ## Deploy
 

--- a/apps/notes/public/admin/config.yml
+++ b/apps/notes/public/admin/config.yml
@@ -39,7 +39,9 @@ collections:
         name: draft
         widget: boolean
         default: false
-        hint: 'Drafts are committed to the repo but never published to the site.'
+        hint: >-
+          Drafts are kept off the blog, feed, tags, and archive, but render at
+          notes.theoazriel.com/drafts/<slug> — an unlisted, noindex preview.
       # `body` is the one reserved field name: it is not frontmatter, it IS
       # the Markdown below the --- fence. Omit it and the CMS shows no
       # content editor at all — every other field still saves fine.

--- a/apps/notes/src/layouts/BaseLayout.astro
+++ b/apps/notes/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import '../styles/global.css';
 const {
   title = 'Theo Azriel’s blog',
   description = 'Working notes about interfaces, systems, and experiments by Theo Azriel.',
+  noindex = false,
 } = Astro.props;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 ---
@@ -14,6 +15,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    {noindex && <meta name="robots" content="noindex" />}
     <meta name="theme-color" content="#ffffff" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title} />

--- a/apps/notes/src/layouts/NoteLayout.astro
+++ b/apps/notes/src/layouts/NoteLayout.astro
@@ -2,7 +2,7 @@
 import BaseLayout from './BaseLayout.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 
-const { title, summary, date, tags = [] } = Astro.props;
+const { title, summary, date, tags = [], draft = false } = Astro.props;
 const dateText = new Intl.DateTimeFormat('en-GB', {
   day: '2-digit',
   month: 'short',
@@ -10,10 +10,15 @@ const dateText = new Intl.DateTimeFormat('en-GB', {
 }).format(date).replace(/ (\d{4})$/, ', $1');
 ---
 
-<BaseLayout title={`${title} — Theo Azriel`} description={summary}>
+<BaseLayout title={`${title} — Theo Azriel`} description={summary} noindex={draft}>
   <SiteHeader />
   <main>
     <article class="post">
+      {draft && (
+        <p class="draft-banner">
+          Draft preview — this note is unlisted until <code>draft: false</code>.
+        </p>
+      )}
       <h1>{title}</h1>
       <p class="note-summary">{summary}</p>
       <p class="note-meta"><time datetime={date.toISOString()}>{dateText}</time></p>

--- a/apps/notes/src/pages/drafts/[...id].astro
+++ b/apps/notes/src/pages/drafts/[...id].astro
@@ -1,0 +1,19 @@
+---
+import { getCollection, render } from 'astro:content';
+import NoteLayout from '../../layouts/NoteLayout.astro';
+
+// The mirror image of /notes/[...id]: only drafts build here. A note is
+// reachable at exactly one of the two URLs, so flipping `draft` moves it
+// rather than duplicating it.
+export async function getStaticPaths() {
+  const notes = await getCollection('notes', ({ data }) => data.draft);
+  return notes.map((note) => ({ params: { id: note.id }, props: { note } }));
+}
+
+const { note } = Astro.props;
+const { Content } = await render(note);
+---
+
+<NoteLayout {...note.data}>
+  <Content />
+</NoteLayout>

--- a/apps/notes/src/pages/drafts/index.astro
+++ b/apps/notes/src/pages/drafts/index.astro
@@ -1,0 +1,30 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import SiteHeader from '../../components/SiteHeader.astro';
+
+const notes = (await getCollection('notes', ({ data }) => data.draft))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+const formatDate = (date: Date) => new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+}).format(date).replace(/ (\d{4})$/, ', $1');
+---
+
+<BaseLayout title="Drafts — Theo Azriel" noindex>
+  <SiteHeader />
+  <main>
+    <h2 id="page-title">Drafts</h2>
+    <p>Unpublished notes. This page is unlisted and hidden from search engines.</p>
+    {notes.length === 0 && <p>No drafts right now.</p>}
+    <ul class="blog-posts" aria-label="Draft notes">
+      {notes.map((note) => (
+        <li>
+          <time datetime={note.data.date.toISOString()}>{formatDate(note.data.date)}</time>
+          <a href={`/drafts/${note.id}`}>{note.data.title}</a>
+        </li>
+      ))}
+    </ul>
+  </main>
+</BaseLayout>

--- a/apps/notes/src/styles/global.css
+++ b/apps/notes/src/styles/global.css
@@ -91,6 +91,14 @@ hr {
 
 img {
   max-width: 100%;
+  /* keep the aspect ratio when Markdown supplies a width attribute */
+  height: auto;
+}
+
+.draft-banner {
+  padding: 8px 12px;
+  border: 1px dashed;
+  font-style: italic;
 }
 
 code {


### PR DESCRIPTION
Two of the four ideas from today's session turned out to be already done (the sites cross-link, and the quotes were removed on purpose), so this PR carries the remaining two.

## Draft previews

Drafts now build at `notes.theoazriel.com/drafts/<slug>` — unlisted, `noindex`, and marked with a dashed "Draft preview" banner — so a note can be proofread in the site's real layout before flipping `draft: false`. `/drafts/` itself is a noindex index of them. The blog, feed, tags, and archive still exclude drafts, and a note is reachable at exactly one of `/notes/` or `/drafts/` at a time.

**Tradeoff to be aware of:** a draft is now technically live at a guessable URL. It's hidden from search engines and never linked, but it is no longer "never published" — the CMS hint and README were updated to say so.

## CMS image uploads

Sveltia was already configured to upload into `apps/notes/public/images` — the folder just didn't exist. It now does (`.gitkeep`), and `img { height: auto }` keeps aspect ratios when Markdown sets a width.

Verified locally: built the site with a scratch draft, confirmed the banner and `noindex` meta on the draft page, and confirmed the draft appears nowhere on the blog, feed, archive, or tag pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)