### PR TITLE
Redirect theoazriel.com/gallery to the gallery subdomain

### DIFF
--- a/apps/gallery/public/_redirects
+++ b/apps/gallery/public/_redirects
@@ -1,0 +1,5 @@
+# Traffic arriving on the legacy theoazriel.com/gallery* route (see
+# wrangler.toml) belongs on the subdomain. These paths never occur on
+# gallery.theoazriel.com itself.
+/gallery https://gallery.theoazriel.com 301
+/gallery/* https://gallery.theoazriel.com/:splat 301

--- a/apps/gallery/wrangler.toml
+++ b/apps/gallery/wrangler.toml
@@ -14,3 +14,9 @@ directory = "./dist"
 [[routes]]
 pattern = "gallery.theoazriel.com"
 custom_domain = true
+
+# Legacy route from the pre-subdomain era. Wrangler cannot delete it, so it
+# stays declared here, and _redirects sends its traffic to the subdomain.
+[[routes]]
+pattern = "theoazriel.com/gallery*"
+zone_name = "theoazriel.com"

--- a/apps/notes/public/_redirects
+++ b/apps/notes/public/_redirects
@@ -1,0 +1,4 @@
+# Convenience paths on the root domain to the subdomain sites.
+/gallery https://gallery.theoazriel.com 301
+/gallery/* https://gallery.theoazriel.com 301
+/home https://home.theoazriel.com 301


### PR DESCRIPTION
Fixes the 404 at theoazriel.com/gallery. A legacy zone route (`theoazriel.com/gallery*`) from the pre-subdomain era still points at the gallery Worker, whose assets have no such paths. Wrangler can't delete zone routes, so the route is now declared in the gallery's wrangler.toml and a `_redirects` file sends its traffic to gallery.theoazriel.com. The notes site also gains `_redirects` for /gallery and /home.

Already deployed and verified: /gallery, /gallery/, and /gallery/x all 301 to the subdomain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)