### PR TITLE
List the sunlight Home among the homepage projects

### DIFF
--- a/apps/notes/src/pages/index.astro
+++ b/apps/notes/src/pages/index.astro
@@ -18,6 +18,10 @@ const notes = (await getCollection('notes', ({ data }) => !data.draft))
 
     <section aria-label="Projects">
       <h2>Projects</h2>
+      <a class="item" href="https://home.theoazriel.com">
+        <span>Home</span>
+        <span class="muted">A quiet room of sunlight, with leaves moving on the wall.</span>
+      </a>
       <a class="item" href="https://gallery.theoazriel.com">
         <span>Gallery</span>
         <span class="muted">Photographs. Places, mostly quiet ones.</span>


### PR DESCRIPTION
Adds home.theoazriel.com to the Projects section on the homepage, described as "A quiet room of sunlight, with leaves moving on the wall." Already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)