### PR TITLE
Stop declaring the gallery's legacy zone route

### DIFF
--- a/apps/gallery/wrangler.toml
+++ b/apps/gallery/wrangler.toml
@@ -17,8 +17,7 @@ not_found_handling = "404-page"
 pattern = "gallery.theoazriel.com"
 custom_domain = true
 
-# Legacy route from the pre-subdomain era. Wrangler cannot delete it, so it
-# stays declared here, and _redirects sends its traffic to the subdomain.
-[[routes]]
-pattern = "theoazriel.com/gallery*"
-zone_name = "theoazriel.com"
+# A legacy route, theoazriel.com/gallery*, still points at this Worker from
+# the pre-subdomain era. It is not declared here: the deploy token has no
+# zone permissions, so declaring it failed every deploy, and wrangler leaves
+# undeclared routes alone. _redirects sends its traffic to the subdomain.


### PR DESCRIPTION
Every gallery deploy has failed at the trigger step since the move to a scoped deploy token: wrangler tries to register `theoazriel.com/gallery*` on the zone and gets an authentication error, after the code and assets have already uploaded.

The route already exists in Cloudflare and wrangler does not remove undeclared routes, so dropping it from `wrangler.toml` keeps the redirect working and makes the deploy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)